### PR TITLE
feat(docker): use distroless base image

### DIFF
--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -1,0 +1,20 @@
+# Download-STAGE
+FROM alpine:3.16.2 as downloader
+
+ARG KUBECTL_VERSION
+ARG TARGETARCH
+
+RUN echo -e "-----------------\nKubectl: ${KUBECTL_VERSION}\nArch: ${TARGETARCH}\n-----------------\n"
+RUN apk add --no-cache -U -u \
+            ca-certificates \
+            curl
+RUN curl -L -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl && \
+    chmod +x /usr/local/bin/kubectl
+
+# Run-STAGE
+FROM gcr.io/distroless/static-debian11:nonroot
+
+WORKDIR /
+COPY --from=downloader /usr/local/bin/kubectl .
+
+ENTRYPOINT ["/kubectl"]


### PR DESCRIPTION
Closes #20

It was tested with success on Oracle Cloud Ampere VMs for arm64 compatibility.

We should discuss considering it as an alternative to the "alpine" flavor or promoting it as the default one