### PR TITLE
ci: weekly checks for new kubectl version

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   check-kubectl-new-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,6 +23,8 @@ jobs:
 
       - name: Create new tag
         if: steps.repository.outputs.version != steps.remote.outputs.version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           git config user.name "Dario Tranchitella"

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -1,0 +1,29 @@
+name: Weekly check
+
+on:
+  schedule:
+    # Every Monday at 9AM
+    - cron: '0 9 * * 1'
+jobs:
+  check-kubectl-new-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get latest tag from the repository
+        id: repository
+        run: echo "version=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+
+      - name: Get latest kubectl release
+        id: remote
+        run: echo "version=$(curl https://cdn.dl.k8s.io/release/stable.txt)" >> $GITHUB_OUTPUT
+
+      - name: Create new tag
+        if: steps.repository.outputs.version != steps.remote.outputs.version
+        shell: bash
+        run: |
+          git config user.name "Dario Tranchitella"
+          git config user.email "dario@tranchitella.eu"
+          git tag -a "${{ steps.remote.outputs.version }}" -m "New release"
+          git push origin "${{ steps.remote.outputs.version }}"

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Create new tag
         if: steps.repository.outputs.version != steps.remote.outputs.version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         shell: bash
         run: |
           git config user.name "Github Actions"

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -27,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
-          git config user.name "Dario Tranchitella"
-          git config user.email "dario@tranchitella.eu"
+          git config user.name "Github Actions"
+          git config user.email 'github-actions@users.noreply.github.com'
           git tag -a "${{ steps.remote.outputs.version }}" -m "New release"
           git push origin "${{ steps.remote.outputs.version }}"

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          fetch-depth: 0
 
       - name: Get latest tag from the repository
         id: repository


### PR DESCRIPTION
According to #25, here's a proposal for a pipeline running once a week to check the latest stable version of kubectl and tag the repository. When that tag is pushed, the other Workflow will run to build the images and release them.

Please, check the git credentials as I used your commit details :eyes: 