### PR TITLE
chore: update alpine to 3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.21.2
+FROM alpine:3.24 AS downloader
 
 ARG KUBECTL_VERSION
 ARG TARGETARCH

--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -1,5 +1,5 @@
 # Download-STAGE
-FROM alpine:3.21.2 AS downloader
+FROM alpine:3.24 AS downloader
 
 ARG KUBECTL_VERSION
 ARG TARGETARCH


### PR DESCRIPTION
Update to alpine 3.24
Since there is no renovate in this repo, update to a minor version instead of patch version, so we always get the latest release in 3.24.